### PR TITLE
suppress ddf deprecation warning

### DIFF
--- a/LiLF/lib_util.py
+++ b/LiLF/lib_util.py
@@ -384,7 +384,7 @@ def run_DDF(s, logfile, **kwargs):
     ddf_parms = []
 
     # basic parms
-    ddf_parms.append( '--Log-Boring 1 --Debug-Pdb never --Parallel-NCPU %i ' % (s.max_processors) )
+    ddf_parms.append( '--Log-Boring 1 --Debug-Pdb never --Parallel-NCPU %i --Misc-IgnoreDeprecationMarking=1 ' % (s.max_processors) )
 
     # cache dir
     if not 'Cache_Dir' in list(kwargs.keys()):


### PR DESCRIPTION
DDF raised a deprecation warning from scipy (version>1.8.0) and crashed. By muting the deprecation warning (as suggested in this pull request), it did not crash and gave the correct output.