### PR TITLE
Make `ulimit` work at runtime

### DIFF
--- a/container/Dockerfile-20250113
+++ b/container/Dockerfile-20250113
@@ -302,4 +302,4 @@ RUN ln -s /usr/bin/ipython3 /usr/bin/ipython
 ENV HDF5_USE_FILE_LOCKING FALSE
 ENV OMP_NUM_THREADS 1
 ENV OPENBLAS_NUM_THREADS 1
-RUN ulimit -n 4000
+ENTRYPOINT [ "ulimit -n 4000" ]


### PR DESCRIPTION
`RUN` only works at build time.