### PR TITLE
Remove DUSE_FFTW3

### DIFF
--- a/container/Dockerfile-20250113
+++ b/container/Dockerfile-20250113
@@ -85,7 +85,7 @@ RUN if [ $MARCH == "broadwell" ]; then \
 RUN cd /opt && git clone --single-branch --branch master https://github.com/casacore/casacore.git \
     && cd /opt/casacore && git checkout tags/v3.6.1
 RUN cd /opt/casacore && mkdir data && cd data && wget --retry-connrefused ftp://anonymous@ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar && tar xf WSRT_Measures.ztar
-RUN cd /opt/casacore && mkdir build && cd build && cmake -DPORTABLE=False -DCMAKE_BUILD_TYPE=Release -DDATA_DIR=/opt/casacore/data -DBUILD_PYTHON=False -DBUILD_PYTHON3=True -DUSE_OPENMP=True -DUSE_FFTW3=True -DUSE_HDF5=True .. && make -j 6 && make install
+RUN cd /opt/casacore && mkdir build && cd build && cmake -DPORTABLE=False -DCMAKE_BUILD_TYPE=Release -DDATA_DIR=/opt/casacore/data -DBUILD_PYTHON=False -DBUILD_PYTHON3=True -DUSE_OPENMP=True -DUSE_HDF5=True .. && make -j 6 && make install
 
 #####################################################################
 ## CASACORE-python v3.6.1


### PR DESCRIPTION
This is no longer supported:
> Manually-specified variables were not used by the project:
> USE_FFTW3

FFTW3 is detected correctly:
> FFTW3 library? ........ = /usr/lib/x86_64-linux-gnu/libfftw3f_threads.so;/usr/lib/x86_64-linux-gnu/libfftw3_threads.so;/usr/lib/x86_64-linux-gnu/libfftw3f.so;/usr/lib/x86_64-linux-gnu/libfftw3.so

BTW: This will no longer build:
https://github.com/revoltek/LiLF/blob/LBAdevel/container/FLoCs-LBAamd3-240823
since Fedora 38 is EOL and it returns 404 error at RPM Fusion.