### PR TITLE
Increase ulimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Check the path for LiLF, let's say it is /opt/LiLF/, and include it in your ~/.b
 
 I also reccommended to set:
 
-`ulimit -n 4000`
+`ulimit -n 8192`
 
 as the pipeline requires to open many files at the same time.
 

--- a/container/Dockerfile-20250113
+++ b/container/Dockerfile-20250113
@@ -301,4 +301,4 @@ RUN ln -s /usr/bin/ipython3 /usr/bin/ipython
 ENV HDF5_USE_FILE_LOCKING FALSE
 ENV OMP_NUM_THREADS 1
 ENV OPENBLAS_NUM_THREADS 1
-ENTRYPOINT [ "ulimit -n 4000" ]
+ENTRYPOINT [ "ulimit -n 8192" ]


### PR DESCRIPTION
I got "too many open files" at `LOFAR_cal.py` when using 4000.