### PR TITLE
Update MKL

### DIFF
--- a/container/Dockerfile-20250113
+++ b/container/Dockerfile-20250113
@@ -75,7 +75,11 @@ ENV PIP_BREAK_SYSTEM_PACKAGES 1
 ##################################################################
 ## Intel specific
 RUN if [ $MARCH == "broadwell" ]; then \
-    apt-get install -y intel-mkl; fi
+    apt-get install -y gpg-agent && \
+    wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list && \
+    apt-get update && \
+    apt-get install -y intel-oneapi-mkl intel-oneapi-mkl-devel; fi
 
 ## end Intel specific
 


### PR DESCRIPTION
Currently very old version 2020.4.304-5 is installed:
https://launchpad.net/ubuntu/+source/intel-mkl

This PR will enable the latest (2025) version. It builds fine.