### PR TITLE
Fix ulimit

### DIFF
--- a/container/Dockerfile-20250113
+++ b/container/Dockerfile-20250113
@@ -301,4 +301,4 @@ RUN ln -s /usr/bin/ipython3 /usr/bin/ipython
 ENV HDF5_USE_FILE_LOCKING FALSE
 ENV OMP_NUM_THREADS 1
 ENV OPENBLAS_NUM_THREADS 1
-ENTRYPOINT [ "ulimit -n 8192" ]
+#ENTRYPOINT [ "ulimit -n 8192" ]


### PR DESCRIPTION
`ENTRYPOINT [ "ulimit -n 8192" ]` returns "executable not found in $PATH" after converting Docker to Apptainer/Singularity.
Maybe it should be sth like:
`ENTRYPOINT ["/bin/bash", "-c", "ulimit", "-n", "8192"]`
but Im not sure.
I would not revert to `RUN` here as it has no effect after the build anyway.
Sorry for the confusion.