### PR TITLE
Comment out `ENV` at the end of Dockerfile

### DIFF
--- a/container/Dockerfile-20250113
+++ b/container/Dockerfile-20250113
@@ -306,10 +306,10 @@ RUN cd /opt/losoto && pip install .
 RUN mkdir /usr/share/casacore/
 RUN ln -s /usr/share/casacore/data/ /opt/casacore/data
 
-ENV LD_LIBRARY_PATH /usr/local/lib:$LD_LIBRARY_PATH
+# ENV LD_LIBRARY_PATH /usr/local/lib:$LD_LIBRARY_PATH
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /usr/bin/ipython3 /usr/bin/ipython
-ENV HDF5_USE_FILE_LOCKING FALSE
-ENV OMP_NUM_THREADS 1
-ENV OPENBLAS_NUM_THREADS 1
+# ENV HDF5_USE_FILE_LOCKING FALSE
+# ENV OMP_NUM_THREADS 1
+# ENV OPENBLAS_NUM_THREADS 1
 #ENTRYPOINT [ "ulimit -n 8192" ]


### PR DESCRIPTION
`ENV` is not available at runtime - it is considered a security risk. `ENV PYTHONPATH /usr/local/lib/python3.12/site-packages/:$PYTHONPATH` will not work at runtime either.

I suggest commenting this out for now, as it may be misleading.