### PR TITLE
Remove EveryBeam artifacts

### DIFF
--- a/container/Dockerfile-20250113
+++ b/container/Dockerfile-20250113
@@ -112,6 +112,7 @@ RUN cd /opt && git clone https://git.astron.nl/RD/EveryBeam.git \
 RUN cd /opt/EveryBeam && mkdir build && cd build \
     && cmake -DDOWNLOAD_LOBES=On -DBUILD_WITH_PYTHON=On .. \
     && make -j 6 && make install
+RUN rm -rf /opt/EveryBeam/
     
 #####################################################################
 ## idg v1.2.0


### PR DESCRIPTION
Lobes (2.3 GB) are copied to `/usr/local/share/everybeam/lobes/` during installation, so they were in two places.