### PR TITLE
Update WSClean

### DIFF
--- a/container/Dockerfile-20250113
+++ b/container/Dockerfile-20250113
@@ -185,7 +185,7 @@ ENV PYTHONPATH /usr/local/lib/python3.12/site-packages/:$PYTHONPATH
 ## Wsclean master (16/1/25)
 #####################################################################
 RUN cd /opt && git clone https://gitlab.com/aroffringa/wsclean.git \
-    && cd /opt/wsclean && git checkout c1e4fcb2
+    && cd /opt/wsclean && git checkout af847af6b39986b18dd06c8e0846fb01f87f36c3
 
 RUN if [ $MARCH == "generic" ]; then \
     cd /opt/wsclean && mkdir build && cd build \


### PR DESCRIPTION
Using the currently checked out commit, I got a core dump crash in `wsclean-c1.log`. Using this newer commit it passes that point and still computing.

> Opening reordered part 1 spw 0 for mss/TC03.MS
> Opening reordered part 1 spw 0 for mss/TC04.MS
> 1 spw Opening reordered part 1 spw 0 for mss/TC05.MS
> Segmentation fault (core dumped)