### PR TITLE
Clean CASACore

### DIFF
--- a/container/Dockerfile-20250113
+++ b/container/Dockerfile-20250113
@@ -96,6 +96,7 @@ RUN cd /opt && git clone --single-branch --branch master https://github.com/casa
     && cd /opt/casacore && git checkout tags/v3.6.1
 RUN cd /opt/casacore && mkdir data && cd data && wget --retry-connrefused ftp://anonymous@ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar && tar xf WSRT_Measures.ztar && rm WSRT_Measures.ztar
 RUN cd /opt/casacore && mkdir build && cd build && cmake -DPORTABLE=False -DCMAKE_BUILD_TYPE=Release -DDATA_DIR=/opt/casacore/data -DBUILD_PYTHON=False -DBUILD_PYTHON3=True -DUSE_OPENMP=True -DUSE_HDF5=True .. && make -j 6 && make install
+RUN cd /opt/casacore && rm -r $(ls -A | grep -v data)
 
 #####################################################################
 ## CASACORE-python v3.6.1


### PR DESCRIPTION
Clean up the CASACore src and build files. Removes everything from `/opt/casacore/` except `data/`.
This folder was 2.6 GiB.