### PR TITLE
Remove libaio

### DIFF
--- a/container/Dockerfile-20250113
+++ b/container/Dockerfile-20250113
@@ -30,7 +30,7 @@ RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 14 && \
     update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-14 14
 
 RUN curl -O http://launchpadlibrarian.net/646633572/libaio1_0.3.113-4_amd64.deb
-RUN dpkg -i libaio1_0.3.113-4_amd64.deb
+RUN dpkg -i libaio1_0.3.113-4_amd64.deb && rm libaio1_0.3.113-4_amd64.deb
 
 # Add group. We chose GID 65527 to try avoiding conflicts.
 RUN groupadd -g 65527 lofar


### PR DESCRIPTION
This is not needed after installation.