### PR TITLE
Fix Dockerfiles labels

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 SHELL ["/bin/bash", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Francesco de Gasperin"
-LABEL version="20250113"
+LABEL version="20250228"
 
 ENV MARCH "generic"
 # AMD v3

--- a/container/Dockerfile-20250228
+++ b/container/Dockerfile-20250228
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 SHELL ["/bin/bash", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Francesco de Gasperin"
-LABEL version="20250113"
+LABEL version="20250228"
 
 ENV MARCH "generic"
 # AMD v3


### PR DESCRIPTION
The new `Dockerfile` seems to be based on `Dockerfile-20250228`, so I updated the labels in both.