### PR TITLE
Remove compiler flags from WSClean AMD

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -224,8 +224,8 @@ RUN if [ $MARCH == "znver3" ]; then \
 #    -DFFTW3_INCLUDE_DIR="${AOCL_ROOT}/include" \
 #    -DBLAS_openblas_LIBRARY="${AOCL_ROOT}/lib/libblis.so" \
 #    -DLAPACK_LIBRARIES="${AOCL_ROOT}/lib/libflame.so" \
-#    -DCMAKE_CXX_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
-#    -DCMAKE_C_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
+#    -DCMAKE_CXX_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm" \
+#    -DCMAKE_C_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm"
 
 #RUN rm -rf /opt/wsclean/
   


### PR DESCRIPTION
If you want it to be super fast, consider also separately benchmarking this on some typical for LiLF WSclean data. WSClean AFAIK has such things in the code, so it might be massing with the defaults. On my 20 GB dataset and Intel/MKL it gets 2.9% faster thanks to removing these flags.