### PR TITLE
Speedup `BLsmooth.py`

### DIFF
--- a/scripts/BLsmooth.py
+++ b/scripts/BLsmooth.py
@@ -196,7 +196,7 @@ for c, idx in enumerate(np.array_split(np.arange(n_bl), options.chunks)):
         logging.debug('Working on baseline: {} - {} (dist = {:.2f}km)'.format(ant1, ant2, dist))
 
         in_bl = slice(i_chunk, -1, len(ants1_chunk))  # All times for 1 BL
-        data, weights= data_chunk[in_bl], weights_chunk[in_bl]
+        # data, weights= data_chunk[in_bl], weights_chunk[in_bl]
 
         std_t = options.ionfactor * (25.e3 / dist) ** options.bscalefactor * (freq / 60.e6)  # in sec
         std_t = std_t / timepersample  # in samples
@@ -208,7 +208,7 @@ for c, idx in enumerate(np.array_split(np.arange(n_bl), options.chunks)):
             std_t, timepersample * std_t, std_f, freqpersample * std_f / 1e6))
         if std_t < 0.5: continue  # avoid very small smoothing and flagged ants
         # fill queue
-        mpm.put([in_bl, data, weights, std_t, std_f])
+        mpm.put([in_bl, data_chunk[in_bl], weights_chunk[in_bl], std_t, std_f])
 
     mpm.wait() # run queue
     # reconstruct chunk column


### PR DESCRIPTION
On my Xeon 6238R `BLsmooth.py` gets 3.4% faster on 18 GB data.