### PR TITLE
Add pip install spherical-geometry

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -276,6 +276,8 @@ RUN cd /opt && git clone https://github.com/cds-astro/mocpy \
     && cd /opt/mocpy && git checkout v0.16.2
 RUN cd /opt/mocpy && pip install .
 
+RUN pip install spherical-geometry
+
 #####################################################################
 # msoverview
 #####################################################################


### PR DESCRIPTION
`LOFAR_ddparallel` is crashing without it.