### PR TITLE
Docker - fix build

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.10
+FROM ubuntu:24.04
 SHELL ["/bin/bash", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Francesco de Gasperin"


### PR DESCRIPTION
Ubuntu 24.10 is not an LTS version and has now reached the end of its life cycle. It will no longer work since the repositories are no longer available.

Ubuntu 25.10 has Python 3.13 ang GCC 15.2 - and I dont know if LiLF is ready for it. But I was able to build the container after upgading some components.