### PR TITLE
Fix Python version

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -186,7 +186,7 @@ RUN if [ $MARCH == "znver3" ]; then \
 
 RUN rm -rf /opt/DP3/
 # add "import dp3"
-ENV PYTHONPATH=/usr/local/lib/python3.12/site-packages/:$PYTHONPATH
+ENV PYTHONPATH=/usr/local/lib/python3.13/site-packages/:$PYTHONPATH
 
 #####################################################################
 ## Wsclean (master 14/2/26)


### PR DESCRIPTION
Ubuntu 25.10 uses Python 3.13. I'm sorry, I missed that in the last PR.