### PR TITLE
Clean MKLs compiler

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -283,6 +283,7 @@ RUN cd /opt && git clone https://github.com/spacetelescope/spherical_geometry/ \
 RUN cd /opt/spherical_geometry && pip install .
 
 RUN rm -rf /opt/{python-casacore,PyBDSF,LSMTool,losoto,RMextract,spinifex,mocpy,spherical_geometry,aoflagger,wsclean}
+RUN rm -rf /opt/intel/oneapi/compiler/latest/bin/
 
 #####################################################################
 # msoverview


### PR DESCRIPTION
This folder is not needed after build. It has 203 MB. `f` makes it safe even if the folder does not exist.