### PR TITLE
CASACore if condition for MKL BLAS

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update
 RUN apt-get install -y cmake texinfo git wget flex bison sudo vim hdf5-tools rename python3-magic htop curl rust-all g++ gfortran \
     python3-dev ipython3 python3-pip python3-setuptools python3-h5py python3-sshtunnel python3-pymysql python3-requests python3-cytoolz python3-tqdm \
     libcfitsio-dev libpng-dev libxml2-dev libarmadillo-dev liblua5.3-dev libfftw3-dev python3-pybind11 wcslib-dev libgsl-dev libblas-dev libaio1t64 libaio-dev \
-    libboost-dev libboost-date-time-dev libboost-filesystem-dev libboost-system-dev libboost-test-dev libboost-python-dev libboost-numpy-dev libboost-program-options-dev libdeflate-dev
+    libboost-dev libboost-date-time-dev libboost-filesystem-dev libboost-system-dev libboost-test-dev libboost-python-dev libboost-numpy-dev libboost-program-options-dev \ 
+    libdeflate-dev
 
 RUN curl -O https://launchpadlibrarian.net/646633572/libaio1_0.3.113-4_amd64.deb
 RUN dpkg -i libaio1_0.3.113-4_amd64.deb && rm libaio1_0.3.113-4_amd64.deb
@@ -99,9 +100,10 @@ RUN apt-get clean
 ## CASACORE master (2/9/25)
 ##################################################################
 RUN cd /opt && git clone --single-branch --branch master https://github.com/casacore/casacore.git \
-    && cd /opt/casacore && git checkout 450a5682a2aa927de123e9953157f3610a5a4f3c
+    && cd /opt/casacore && git checkout 450a568
 RUN cd /opt/casacore && mkdir data && cd data && wget --retry-connrefused --no-verbose https://www.astron.nl/iers/WSRT_Measures.ztar && tar xf WSRT_Measures.ztar && rm WSRT_Measures.ztar
-RUN cd /opt/casacore && mkdir build && cd build && cmake -DPORTABLE=False -DCMAKE_BUILD_TYPE=Release -DDATA_DIR=/opt/casacore/data -DUSE_OPENMP=True -DUSE_HDF5=True -DBUILD_SISCO=ON -DBLA_VENDOR=Intel10_64lp .. && make -j `nproc --all` && make install
+RUN if [ $MARCH == "broadwell" ]; then cd /opt/casacore && mkdir build && cd build && cmake -DPORTABLE=False -DCMAKE_BUILD_TYPE=Release -DDATA_DIR=/opt/casacore/data -DUSE_OPENMP=True -DUSE_HDF5=True -DBUILD_SISCO=ON -DBLA_VENDOR=Intel10_64lp .. && make -j `nproc --all` && make install; fi
+RUN if [ $MARCH != "broadwell" ]; then cd /opt/casacore && mkdir build && cd build && cmake -DPORTABLE=False -DCMAKE_BUILD_TYPE=Release -DDATA_DIR=/opt/casacore/data -DUSE_OPENMP=True -DUSE_HDF5=True -DBUILD_SISCO=ON .. && make -j `nproc --all` && make install; fi
 RUN cd /opt/casacore && rm -r $(ls -A | grep -v data)
 
 #####################################################################


### PR DESCRIPTION
Make sure that outside `broadwell` mode it does not try to find MKL BLAS libs.