### PR TITLE
Remove `libmkl_sycl`

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -82,7 +82,8 @@ RUN if [ $MARCH == "broadwell" ]; then \
     apt-get update && \
     apt-get install -y intel-oneapi-mkl intel-oneapi-mkl-devel \
     &&  apt-get clean \
-    && rm -rf /opt/intel/oneapi/compiler/latest/bin/; fi
+    && rm -rf /opt/intel/oneapi/compiler/latest/bin/ \
+    && rm -f /opt/intel/oneapi/mkl/latest/lib/libmkl_sycl.a; fi
 
 # Silence UndefinedVar warning from BuildKit Dockerfile linter
 ENV PKG_CONFIG_PATH="" CMAKE_PREFIX_PATH="" LIBRARY_PATH="" LD_LIBRARY_PATH="" CPATH="" PYTHONPATH=""


### PR DESCRIPTION
Shrinks the image in `broadwell` mode by 1 GB. This library is not needed as long as SYCL (platform independent code) is not used.
> [...] enable different heterogeneous devices to be used in a single application — for example simultaneous use of CPUs, GPUs, and FPGAs