### PR TITLE
Remove duplicated `LD_LIBRARY_PATH`

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -331,7 +331,6 @@ RUN pip install --root-user-action=ignore \
 RUN mkdir /usr/share/casacore/
 RUN ln -s /usr/share/casacore/data/ /opt/casacore/data
 
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /usr/bin/ipython3 /usr/bin/ipython
 ENV HDF5_USE_FILE_LOCKING=FALSE


### PR DESCRIPTION
`ldconfig -v 2>/dev/null | grep /usr/local/lib` in runtime shows that the path is already in the linker, so better not to duplicate it.