### PR TITLE
Fix EveryBeam <=> DP3 conflict

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -137,10 +137,10 @@ RUN cd /opt && \
 #RUN cd /opt/python-casacore && pip install .
 
 #####################################################################
-## EveryBeam v0.8.2
+## EveryBeam (master 07/05/2026)
 #####################################################################
 RUN cd /opt && git clone https://git.astron.nl/RD/EveryBeam.git \
-    && cd /opt/EveryBeam && git checkout tags/v0.8.2 && rm -rf .git/objects/pack/
+    && cd /opt/EveryBeam && git checkout ef6f1ece && rm -rf .git/objects/pack/
 RUN cd /opt/EveryBeam && mkdir build && cd build \
     && cmake -Wno-dev -DDOWNLOAD_LOBES=Off -DBUILD_WITH_PYTHON=On .. \
     && make -j `nproc --all` && make install \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -275,6 +275,19 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && rm -rf /root/.cache/pip
 
 #####################################################################
+## EveryBeam (master 07/05/2026)
+#####################################################################
+# Temporary fix to overwrite everybeam 0.8.2 (now too old) installed from PyPI as a dependency.
+# Otherwise `import everybeam` won't work:
+# ImportError: /usr/local/lib/python3.13/dist-packages/everybeam.cpython-313-x86_64-linux-gnu.so: undefined symbol: _ZTIN9everybeam8casacore12MConvertBaseE
+RUN cd /opt && git clone https://git.astron.nl/RD/EveryBeam.git \
+    && cd /opt/EveryBeam && git checkout ef6f1ece && rm -rf .git/objects/pack/
+RUN cd /opt/EveryBeam && mkdir build && cd build \
+    && cmake -Wno-dev -DDOWNLOAD_LOBES=Off -DBUILD_WITH_PYTHON=On .. \
+    && make -j `nproc --all` && make install \
+    && rm -rf /opt/EveryBeam/
+
+#####################################################################
 # msoverview
 #####################################################################
 #RUN cd /opt && mkdir -p msoverview/src && cd msoverview/src && wget https://git.astron.nl/ro/lofar/-/raw/LOFAR-Release-4_0_17/CEP/MS/src/msoverview.cc \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -107,12 +107,12 @@ ENV CPATH=/opt/intel/oneapi/mkl/latest/include:$CPATH
 ## end Intel specific
 
 ##################################################################
-## CASACore master (2/9/25)
+## CASACore master (07/05/2026)
 ##################################################################
 RUN cd /opt && \
     git clone --single-branch --filter=blob:none --branch master https://github.com/casacore/casacore.git && \
     cd casacore && \
-    git checkout 450a568 && \
+    git checkout aaf72eb && \
     mkdir data && cd data && \
     wget --retry-connrefused --no-verbose https://www.astron.nl/iers/WSRT_Measures.ztar && \
     tar xf WSRT_Measures.ztar && \


### PR DESCRIPTION
`import dp3`
produced:

> Traceback (most recent call last):
>   File "<python-input-4>", line 1, in <module>
>     import dp3
>   File "/usr/local/lib/python3.13/site-packages/dp3/__init__.py", line 6, in <module>
>     from . import parameterset, pydp3
> ImportError: /usr/local/lib/libDP3.so: undefined symbol: _ZN9everybeam21ReadTileBeamDirectionERKN8casacore14MeasurementSetE

Fixed by updating EveryBeam to current master.

CASACore also has to be updated, otherwise in turn `import everybeam` crashes in similar way.

EDIT:
There is a chance that it fixes also https://github.com/revoltek/LiLF/issues/211.