### PR TITLE
Add Python import test

### DIFF
--- a/container/tests/imports.sh
+++ b/container/tests/imports.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Inside the container, clone LiLF, cd to its directory and paste the following:
+
+python - <<'PY'
+import ast
+import pathlib
+import importlib.util
+import sys
+
+root = pathlib.Path(".")
+
+stdlib = set(sys.stdlib_module_names)
+
+for path in root.rglob("*.py"):
+
+    try:
+        txt = path.read_text(errors="ignore")
+        tree = ast.parse(txt)
+    except Exception:
+        continue
+
+    for node in ast.walk(tree):
+
+        modules = []
+
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                modules.append((n.name.split(".")[0], n.name))
+
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                modules.append(
+                    (node.module.split(".")[0], node.module)
+                )
+
+        for topmod, fullname in modules:
+
+            if topmod in stdlib:
+                continue
+
+            if importlib.util.find_spec(topmod) is None:
+
+                print(f"\nMISSING: {topmod}")
+                print(f"FILE:    {path}")
+                print(f"LINE:    {node.lineno}")
+
+                line = txt.splitlines()[node.lineno - 1]
+                print(f"CODE:    {line.strip()}")
+PY


### PR DESCRIPTION
This will scan the entire cloned repository, looking for erroneous imports. The current output for the master branch is as follows:

```
MISSING: xmlrpclib
FILE:    scripts/stager_[access.py](http://access.py/)
LINE:    23
CODE:    import xmlrpclib

MISSING: stager_access
FILE:    scripts/LOFAR_[stager.py](http://stager.py/)
LINE:    22
CODE:    import stager_access as stager

MISSING: download_file
FILE:    scripts/LOFAR_[stager.py](http://stager.py/)
LINE:    26
CODE:    from download_file import download_file

MISSING: bokeh
FILE:    scripts/[breizorro.py](http://breizorro.py/)
LINE:    352
CODE:    from [bokeh.models](http://bokeh.models/) import BoxEditTool, ColumnDataSource, FreehandDrawTool

MISSING: bokeh
FILE:    scripts/[breizorro.py](http://breizorro.py/)
LINE:    353
CODE:    from [bokeh.plotting](http://bokeh.plotting/) import figure, output_file, show

MISSING: bokeh
FILE:    scripts/[breizorro.py](http://breizorro.py/)
LINE:    354
CODE:    from [bokeh.io](http://bokeh.io/) import curdoc

MISSING: surveys_db
FILE:    scripts/LOFAR_[dbobs.py](http://dbobs.py/)
LINE:    7
CODE:    from surveys_db import SurveysDB

MISSING: dppp
FILE:    LiLF/[polconv.py](http://polconv.py/)
LINE:    32
CODE:    from dppp import DPStep as Step

MISSING: MySQLdb
FILE:    LiLF/surveys_[db.py](http://db.py/)
LINE:    9
CODE:    import MySQLdb as mdb

MISSING: MySQLdb
FILE:    LiLF/surveys_[db.py](http://db.py/)
LINE:    10
CODE:    import [MySQLdb.cursors](http://mysqldb.cursors/) as mdbcursors

MISSING: ConfigParser
FILE:    LiLF/lib_[util.py](http://util.py/)
LINE:    23
CODE:    from ConfigParser import ConfigParser
```

Some of this looks like leftovers from Python 2, eg. change the first and the last one to:
```
from xmlrpc import client
import configparser
```