### PR TITLE
Fine-tune import test

### DIFF
--- a/container/tests/imports.sh
+++ b/container/tests/imports.sh
@@ -5,15 +5,22 @@
 python - <<'PY'
 import ast
 import pathlib
-import importlib.util
+import importlib
+import warnings
 import sys
 
-root = pathlib.Path(".")
+# Hide SyntaxWarning: invalid escape sequence '\['
+warnings.filterwarnings(
+    "ignore",
+    message=r"invalid escape sequence",
+    category=SyntaxWarning,
+)
 
+root = pathlib.Path(".")
 stdlib = set(sys.stdlib_module_names)
+checked = set()
 
 for path in root.rglob("*.py"):
-
     try:
         txt = path.read_text(errors="ignore")
         tree = ast.parse(txt)
@@ -21,9 +28,7 @@ for path in root.rglob("*.py"):
         continue
 
     for node in ast.walk(tree):
-
         modules = []
-
         if isinstance(node, ast.Import):
             for n in node.names:
                 modules.append((n.name.split(".")[0], n.name))
@@ -35,16 +40,43 @@ for path in root.rglob("*.py"):
                 )
 
         for topmod, fullname in modules:
-
             if topmod in stdlib:
                 continue
 
-            if importlib.util.find_spec(topmod) is None:
+            key = (topmod, path, node.lineno)
+            if key in checked:
+                continue
+            checked.add(key)
+            line = txt.splitlines()[node.lineno - 1].strip()
 
+            try:
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    importlib.import_module(topmod)
+                    if w:
+                        print(f"\nWARNING: {topmod}")
+                        print(f"FILE:    ./{path}")
+                        print(f"LINE:    {node.lineno}")
+                        print(f"CODE:    {line}")
+
+                        for warn in w:
+                            print(
+                                f"WARN:    "
+                                f"{warn.category.__name__}: "
+                                f"{warn.message}"
+                            )
+
+            except ModuleNotFoundError:
                 print(f"\nMISSING: {topmod}")
-                print(f"FILE:    {path}")
+                print(f"FILE:    ./{path}")
                 print(f"LINE:    {node.lineno}")
+                print(f"CODE:    {line}")
 
-                line = txt.splitlines()[node.lineno - 1]
-                print(f"CODE:    {line.strip()}")
+            except Exception as e:
+                print(f"\nERROR:   {topmod}")
+                print(f"FILE:    ./{path}")
+                print(f"LINE:    {node.lineno}")
+                print(f"CODE:    {line}")
+                print(f"EXC:     {type(e).__name__}: {e}")
+
 PY


### PR DESCRIPTION
Now it will show also modules producing warning during import. The output is as below.
It also shows, that https://github.com/revoltek/LiLF/issues/211 is either fixed, not produced by importing, or not produced by LiLF code.

> MISSING: xmlrpclib
> FILE:    ./scripts/stager_access.py
> LINE:    23
> CODE:    import xmlrpclib
> 
> MISSING: stager_access
> FILE:    ./scripts/LOFAR_stager.py
> LINE:    22
> CODE:    import stager_access as stager
> 
> MISSING: download_file
> FILE:    ./scripts/LOFAR_stager.py
> LINE:    26
> CODE:    from download_file import download_file
> 
> MISSING: bokeh
> FILE:    ./scripts/breizorro.py
> LINE:    352
> CODE:    from bokeh.models import BoxEditTool, ColumnDataSource, FreehandDrawTool
> 
> MISSING: bokeh
> FILE:    ./scripts/breizorro.py
> LINE:    353
> CODE:    from bokeh.plotting import figure, output_file, show
> 
> MISSING: bokeh
> FILE:    ./scripts/breizorro.py
> LINE:    354
> CODE:    from bokeh.io import curdoc
> 
> MISSING: surveys_db
> FILE:    ./scripts/LOFAR_dbobs.py
> LINE:    7
> CODE:    from surveys_db import SurveysDB
> 
> WARNING: pyregion
> FILE:    ./LiLF/lib_dd.py
> LINE:    7
> CODE:    import pyregion
> WARN:    PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
> WARN:    PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
> WARN:    PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
> WARN:    PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
> WARN:    PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
> WARN:    PyparsingDeprecationWarning: 'leaveWhitespace' deprecated - use 'leave_whitespace'
> WARN:    PyparsingDeprecationWarning: 'leaveWhitespace' deprecated - use 'leave_whitespace'
> WARN:    PyparsingDeprecationWarning: 'leaveWhitespace' deprecated - use 'leave_whitespace'
> WARN:    PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
> WARN:    PyparsingDeprecationWarning: 'leaveWhitespace' deprecated - use 'leave_whitespace'
> WARN:    PyparsingDeprecationWarning: 'leaveWhitespace' deprecated - use 'leave_whitespace'
> WARN:    PyparsingDeprecationWarning: 'leaveWhitespace' deprecated - use 'leave_whitespace'
> WARN:    PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
> WARN:    PyparsingDeprecationWarning: 'leaveWhitespace' deprecated - use 'leave_whitespace'
> WARN:    PyparsingDeprecationWarning: 'leaveWhitespace' deprecated - use 'leave_whitespace'
> WARN:    PyparsingDeprecationWarning: 'leaveWhitespace' deprecated - use 'leave_whitespace'
> WARN:    PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
> 
> MISSING: dppp
> FILE:    ./LiLF/polconv.py
> LINE:    32
> CODE:    from dppp import DPStep as Step
> 
> MISSING: MySQLdb
> FILE:    ./LiLF/surveys_db.py
> LINE:    9
> CODE:    import MySQLdb as mdb
> 
> MISSING: MySQLdb
> FILE:    ./LiLF/surveys_db.py
> LINE:    10
> CODE:    import MySQLdb.cursors as mdbcursors
> 
> MISSING: ConfigParser
> FILE:    ./LiLF/lib_util.py
> LINE:    23
> CODE:    from ConfigParser import ConfigParser