### PR TITLE
Group logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ ENV/
 .DS_Store
 pipelines/LOFAR_ddparallel_test.py
 pipelines/LOFAR_cal_test.py
+
+# LiLF specific
+logs/

--- a/LiLF/lib_log.py
+++ b/LiLF/lib_log.py
@@ -76,8 +76,8 @@ class Logger():
 
         # Build timestamped names for this run's log file and log directory.
         timestamp = time.strftime('%Y-%m-%d_%H:%M:%S', time.localtime())
-        self.logfile = pipename + '_' + timestamp + '.logger'
-        self.log_dir = 'logs_' + pipename + '_' + timestamp
+        self.logfile = "logs/" + pipename + '_' + timestamp + '.logger'
+        self.log_dir = 'logs/logs_' + pipename + '_' + timestamp
         os.makedirs(self.log_dir)
 
         self.set_logger(self.logfile)
@@ -85,10 +85,10 @@ class Logger():
         # Create 'latest' symlinks so users can always find the most recent
         # logs without knowing the timestamp.  A temp-then-rename pattern is
         # used so the replacement is atomic and never leaves a broken link.
-        os.symlink(self.log_dir, f'logs_{pipename}.tmp')
-        os.rename(f'logs_{pipename}.tmp', f'logs_{pipename}')
-        os.symlink(self.logfile, pipename + '.logger.tmp')
-        os.rename(pipename + '.logger.tmp', pipename + '.logger')
+        os.symlink(self.log_dir, f'logs/logs_{pipename}.tmp')
+        os.rename(f'logs/logs_{pipename}.tmp', f'logs/logs_{pipename}')
+        os.symlink(self.logfile, "logs/" + pipename + '.logger.tmp')
+        os.rename("logs/" + pipename + '.logger.tmp', "logs/" + pipename + '.logger')
 
     def set_logger(self, logfile):
         """Configure the 'LiLF' named logger with a file handler and a

--- a/LiLF/lib_log.py
+++ b/LiLF/lib_log.py
@@ -75,9 +75,11 @@ class Logger():
         root.handlers = []
 
         # Build timestamped names for this run's log file and log directory.
-        timestamp = time.strftime('%Y-%m-%d_%H:%M:%S', time.localtime())
-        self.logfile = "logs/" + pipename + '_' + timestamp + '.logger'
-        self.log_dir = 'logs/logs_' + pipename + '_' + timestamp
+        timestamp = time.strftime("%Y-%m-%d_%H:%M:%S", time.localtime())
+        log_location = f"logs/logs_{timestamp}"
+        self.logfile = f"{log_location}/{pipename}.logger"
+        self.log_dir = f"{log_location}/logs_{pipename}"
+
         os.makedirs(self.log_dir)
 
         self.set_logger(self.logfile)
@@ -85,10 +87,12 @@ class Logger():
         # Create 'latest' symlinks so users can always find the most recent
         # logs without knowing the timestamp.  A temp-then-rename pattern is
         # used so the replacement is atomic and never leaves a broken link.
-        os.symlink(self.log_dir, f'logs/logs_{pipename}.tmp')
-        os.rename(f'logs/logs_{pipename}.tmp', f'logs/logs_{pipename}')
-        os.symlink(self.logfile, "logs/" + pipename + '.logger.tmp')
-        os.rename("logs/" + pipename + '.logger.tmp', "logs/" + pipename + '.logger')
+        # Note that the symlinks will already live in the logs/ dir, so they
+        # must link to the timestamp folder directly, or we link to logs/logs/
+        os.symlink(f"logs_{timestamp}/logs_{pipename}", f"logs/logs_{pipename}.tmp")
+        os.rename(f"logs/logs_{pipename}.tmp", f"logs/logs_{pipename}")
+        os.symlink(f"logs_{timestamp}/{pipename}.logger", f"logs/{pipename}.logger.tmp")
+        os.rename(f"logs/{pipename}.logger.tmp", f"logs/{pipename}.logger")
 
     def set_logger(self, logfile):
         """Configure the 'LiLF' named logger with a file handler and a

--- a/PiLL.py
+++ b/PiLL.py
@@ -24,7 +24,7 @@ def check_done(step: lib_cfg.Step):
     Raises RuntimeError so the caller can decide how to handle it (the walker
     will not mark the step as done and it will be retried on the next run).
     """
-    pattern = f'pipeline-{step.kind}-{step.name}_*.logger'
+    pattern = f'logs/pipeline-{step.kind}-{step.name}.logger'
     matches = sorted(glob.glob(pattern))
     if not matches:
         raise RuntimeError(


### PR DESCRIPTION
Hey there, 

I am Timo, programmer at ASTRON. Henrik introduced me to the pipeline. Our eventual aim is for me to have LiLF run in the ASTRON Science Data Center as a default pipeline. In the short term I will be seeing if I can get the Dask SLURM scheduler approach running that you guys started before. For now, I would like to try to start with some general, low stakes, quality of life improvements. I am very much still learning about this pipeline so please let me know if my proposed changes are not desirable. Also, please let me know if there are particular parts of the pipeline that you would like help with.

--------

After running the pipeline  a few times, I ended up with a project directory full of log files. In this PR I group the log files in a logs directory for a cleaner workspace. All the information is still there.

An example of what the logs directory now looks like for me after using this branch:

<img width="626" height="142" alt="image" src="https://github.com/user-attachments/assets/0ba25be5-181b-4af1-8e4d-9159e4580e8e" />

Where of course PiLL.logger is a symlink to the equivalent name in the most recent subdirectory logs_2026-06-23_16:24:05/logs_PiLL