### PR TITLE
Timesplit lofar2 restructure

### DIFF
--- a/LiLF/lib_cfg.py
+++ b/LiLF/lib_cfg.py
@@ -49,8 +49,8 @@ DEFAULTS = {
         'use_shm':                False,
     },
     'timesplit': {
-        'data_dir':               'data-bkp/',
-        'cal_dir':                '',
+        'input_mss':              'data-bkp/',
+        'input_h5':               '',
         'ngroups':                1,
         'initc':                  0,
         'apply_fr':               False,

--- a/LiLF/pipelines/timesplit.py
+++ b/LiLF/pipelines/timesplit.py
@@ -19,8 +19,8 @@ def run(step):
     w = lib_walker.Walker(f'pipeline-{step.kind}-{step.name}.walker')
 
     parset_dir = step['parset_dir']
-    data_dir = step['data_dir']
-    cal_dir = step['cal_dir']
+    data_dir = step['input_mss']
+    cal_dir = step['input_h5']
     fillmissingedges = step['fill_missing_edges']
     ngroups = step['ngroups']
     initc = step['initc']
@@ -196,7 +196,7 @@ def run(step):
     with w.if_todo('flag'):
         logger.info('Flagging...')
         flag_strat = '/HBAdefaultwideband.lua' if MSs.isHBA else '/LBAdefaultwideband.lua'
-        MSs.run('DP3 '+parset_dir+'/DP3-flag.parset msin=$pathMS ant.baseline=\"' + bl2flag + '\" \
+        MSs.run('DP3 '+parset_dir+'/DP3-flag.parset msin=$pathMS ant.baseline=\"' + flag_ants + '\" \
                 aoflagger.strategy='+parset_dir+flag_strat, log='$nameMS_DP3_flag.log', commandType='DP3')
 
         if MSs.hasIS:


### PR DESCRIPTION
Hey all,

After some trail and error, these are the minimal changes I found for the timesplit step to be runnable on the LOFAR2restructure branch. Of course I am not very well acquainted with the pipeline as a whole quite yet, so please let me know if I missed something critical.

The names of `input_mss` and `input_h5` are used here to match the following line:
https://github.com/revoltek/LiLF/blob/28c37a0deb0f3154d5c14fd5a3e2f46024064db7/LiLF/lib_cfg.py#L111

Cheers,
Timo